### PR TITLE
feat: multi file prisma schema folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,9 @@
     "esbuild": "^0.19.12",
     "eslint": "^8.57.0",
     "shx": "^0.3.4",
-    "typescript": "^5.4.5"
+    "typescript": "^5.5.4"
   },
   "dependencies": {
-    "@prisma/internals": "^5.13.0"
+    "@prisma/internals": "^5.18.0"
   }
 }


### PR DESCRIPTION
Enable support for multiple schema files (`prismaSchemaFolder` preview feature).

Instead of using the current editor content, this PR will try the editor path file to get the schema. If it fails, it will try the path's parent folder. If this also fails, then it will throw an Error.